### PR TITLE
Fix login endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ O sistema cria automaticamente um usuário administrador:
 ## 📚 Endpoints da API
 
 ### Autenticação
-- `POST /auth/login` - Login do usuário
-- `GET /auth/verify` - Verificar token
-- `POST /auth/logout` - Logout
-- `PUT /auth/change-password` - Alterar senha
+- `POST /api/login` - Login do usuário
+- `GET /api/verify` - Verificar token
+- `POST /api/logout` - Logout
+- `PUT /api/change-password` - Alterar senha
 
 ### Usuários
 - `GET /api/users` - Listar usuários (admin/manager)
@@ -201,7 +201,7 @@ O sistema cria automaticamente um usuário administrador:
 
 ```bash
 # Testar endpoint de login
-curl -X POST http://localhost:5000/auth/login \
+curl -X POST http://localhost:5000/api/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"Lima12345"}'
 

--- a/app.js
+++ b/app.js
@@ -85,7 +85,9 @@ app.get('/', (req, res) => {
 });
 
 // Importar e usar rotas
-app.use('/auth', require('./src/routes/auth'));
+// As rotas de autenticação agora são montadas em '/api'
+// para que o endpoint de login esteja disponível em POST /api/login
+app.use('/api', require('./src/routes/auth'));
 app.use('/api/processes', require('./src/routes/processes'));
 app.use('/api/tasks', require('./src/routes/tasks'));
 app.use('/api/users', require('./src/routes/users'));

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -5,6 +5,9 @@ const { auth } = require('../middleware/auth');
 
 const router = express.Router();
 
+// Todas as rotas deste arquivo serão acessadas com o prefixo '/api'
+// definido em app.js
+
 // Login
 router.post('/login', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- make auth routes available under `/api`
- clarify prefix in auth router
- update docs to reflect `/api/login`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68653da144bc8329a212958e1d9cdf54