### PR TITLE
fix(app): enable trust proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const rateLimit = require('express-rate-limit');
 require('dotenv').config();
 
 const app = express();
+app.set('trust proxy', 1);
 
 // Middlewares de segurança
 app.use(helmet());


### PR DESCRIPTION
## Summary
- enable trust proxy for reverse proxy support

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68654f77f8b08329a01cf5ae60f6373a