### PR TITLE
Fix trust proxy placement for rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ O sistema cria automaticamente um usuário administrador:
 ## 📚 Endpoints da API
 
 ### Autenticação
-- `POST /auth/login` - Login do usuário
-- `GET /auth/verify` - Verificar token
-- `POST /auth/logout` - Logout
-- `PUT /auth/change-password` - Alterar senha
+- `POST /api/login` - Login do usuário
+- `GET /api/verify` - Verificar token
+- `POST /api/logout` - Logout
+- `PUT /api/change-password` - Alterar senha
 
 ### Usuários
 - `GET /api/users` - Listar usuários (admin/manager)
@@ -201,7 +201,7 @@ O sistema cria automaticamente um usuário administrador:
 
 ```bash
 # Testar endpoint de login
-curl -X POST http://localhost:5000/auth/login \
+curl -X POST http://localhost:5000/api/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"Lima12345"}'
 

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const rateLimit = require('express-rate-limit');
 require('dotenv').config();
 
 const app = express();
-// Trust proxy to read X-Forwarded headers (required for rate limiting)
+// ✅ Corrigido: precisa vir logo após o app ser criado
 app.set('trust proxy', 1);
 
 // Middlewares de segurança
@@ -19,11 +19,11 @@ app.use(cors({
 // Rate limiting
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutos
-  max: 100 // máximo 100 requests por IP
+  max: 100 // máximo 100 requisições por IP
 });
 app.use(limiter);
 
-// Middlewares
+// Middlewares padrão
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true }));
 
@@ -76,7 +76,7 @@ const createAdminUser = async () => {
   }
 };
 
-// Rotas
+// Rota principal
 app.get('/', (req, res) => {
   res.json({ 
     message: 'ProcessFlow backend em execução',
@@ -87,15 +87,14 @@ app.get('/', (req, res) => {
 });
 
 // Importar e usar rotas
-// As rotas de autenticação foram montadas em '/api'
-// para que o endpoint de login funcione em POST /api/login
+// ✅ Rotas organizadas
 app.use('/api', require('./src/routes/auth'));
 app.use('/api/processes', require('./src/routes/processes'));
 app.use('/api/tasks', require('./src/routes/tasks'));
 app.use('/api/users', require('./src/routes/users'));
 app.use('/api/teams', require('./src/routes/teams'));
 
-// Middleware de erro global
+// Middleware global de erro
 app.use((err, req, res, next) => {
   console.error('❌ Erro:', err.stack);
   res.status(500).json({ 
@@ -109,7 +108,7 @@ app.use('*', (req, res) => {
   res.status(404).json({ error: 'Rota não encontrada' });
 });
 
-// Iniciar servidor
+// Inicialização do servidor
 const PORT = process.env.PORT || 5000;
 
 const startServer = async () => {

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const rateLimit = require('express-rate-limit');
 require('dotenv').config();
 
 const app = express();
-// Trust the first proxy to get real client IP (needed for rate limiting)
+// Trust proxy to read X-Forwarded headers (required for rate limiting)
 app.set('trust proxy', 1);
 
 // Middlewares de segurança

--- a/app.js
+++ b/app.js
@@ -6,6 +6,8 @@ const rateLimit = require('express-rate-limit');
 require('dotenv').config();
 
 const app = express();
+// Trust the first proxy to get real client IP (needed for rate limiting)
+app.set('trust proxy', 1);
 
 // Middlewares de segurança
 app.use(helmet());
@@ -85,7 +87,9 @@ app.get('/', (req, res) => {
 });
 
 // Importar e usar rotas
-app.use('/auth', require('./src/routes/auth'));
+// As rotas de autenticacao foram montadas em '/api'
+// para que o endpoint de login funcione em POST /api/login
+app.use('/api', require('./src/routes/auth'));
 app.use('/api/processes', require('./src/routes/processes'));
 app.use('/api/tasks', require('./src/routes/tasks'));
 app.use('/api/users', require('./src/routes/users'));

--- a/app.js
+++ b/app.js
@@ -87,7 +87,7 @@ app.get('/', (req, res) => {
 });
 
 // Importar e usar rotas
-// As rotas de autenticacao foram montadas em '/api'
+// As rotas de autenticação foram montadas em '/api'
 // para que o endpoint de login funcione em POST /api/login
 app.use('/api', require('./src/routes/auth'));
 app.use('/api/processes', require('./src/routes/processes'));


### PR DESCRIPTION
## Summary
- document auth routes under `/api`
- mount auth router at `/api`
- configure Express trust proxy before rate limiter to prevent warnings

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68653da144bc8329a212958e1d9cdf54